### PR TITLE
Update to use the setting UsePSI instead of UsePsi which caused errors.

### DIFF
--- a/Source/RW_ColonistBarKF/Bar/ColonistBarDrawLocsFinderKF.cs
+++ b/Source/RW_ColonistBarKF/Bar/ColonistBarDrawLocsFinderKF.cs
@@ -90,7 +90,7 @@ namespace ColonistBarKF
 
         private static float SpacingHorizontalPSI()
         {
-            if (ColBarSettings.UsePsi)
+            if (ColBarSettings.UsePSI)
                 if (ColBarSettings.ColBarPsiIconPos == Position.Alignment.Left || ColBarSettings.ColBarPsiIconPos == Position.Alignment.Right)
                 {
 
@@ -101,7 +101,7 @@ namespace ColonistBarKF
 
         private static float SpacingVerticalPSIAssumingScale(float scale)
         {
-            if (ColBarSettings.UsePsi)
+            if (ColBarSettings.UsePSI)
                 if (ColBarSettings.ColBarPsiIconPos == Position.Alignment.Bottom || ColBarSettings.ColBarPsiIconPos == Position.Alignment.Top)
                 {
                     return ColBarSettings.BaseSizeFloat / ColBarSettings.IconsInColumn * scale * PsiRowsOnBar;


### PR DESCRIPTION
Attempt to use string UsePsi to refer to field UsePSI in type ColonistBarKF.SettingsPSI; xml tags are now case-sensitive. XML